### PR TITLE
Update AuxCo cases with kldb/isco specific questions to use aggregation blocks

### DIFF
--- a/auxco_src_files/4_Naturwissenschaft_Geografie_und_Informatik/4035_Betriebsinformatiker-in.xml
+++ b/auxco_src_files/4_Naturwissenschaft_Geografie_und_Informatik/4035_Betriebsinformatiker-in.xml
@@ -31,35 +31,24 @@
     </fragetext>
     <antwort position="1">
       <text>Konzeption von speziellen IT-Systemen für verschiedene Aufgaben und Anwenderbedürfnisse</text>
-      <isco schluessel="2511">Systems analysts</isco>
     </antwort>
     <antwort position="2">
       <text>Entwurf und Entwicklung von Computersoftware</text>
-      <isco schluessel="2512">Software developers</isco>
     </antwort>
     <antwort position="3">
       <text>Entwicklung und Entwurf von Webseiten und Online-shops/ E-Commerce</text>
-      <isco schluessel="2513">Web and Multimedia Developers</isco>
     </antwort>
     <antwort position="4">
       <text>Entwicklung und Wartung von Code</text>
-      <isco schluessel="2514">Application Programmers</isco>
     </antwort>
     <antwort position="5">
       <text>Entwicklung, Kontrolle und Wartung von Datenbanken</text>
-      <isco schluessel="2521">Database Designers and Administrators</isco>
     </antwort>
     <antwort position="6">
       <text>Wartung und Verwaltung von informationstechnischen Systemen</text>
-      <isco schluessel="2522">Systems Administrators</isco>
     </antwort>
     <antwort position="7">
       <text>Erforschung und Weiterentwicklung von Netzwerkarchitekturen zur Leistungsoptimierung</text>
-      <isco schluessel="2523">Computer Network Professionals</isco>
-    </antwort>
-    <antwort position="8">
-      <text>Oder etwas anderes?</text>
-      <isco schluessel="????">Freitextantwort</isco>
     </antwort>
     <fragetext typ="anforderungsniveau">
       <folgefrageAktuellerBeruf>Welche Art von Ausbildung ist für Ihre Tätigkeit in der Regel erforderlich?</folgefrageAktuellerBeruf>
@@ -67,20 +56,133 @@
     </fragetext>
     <antwort position="1" anforderungsniveau="2">
       <text>eine abgeschlossene Berufsausbildung</text>
-      <kldb schluessel="43112">Berufe in der Wirtschaftsinformatik - fachlich ausgerichtete Tätigkeiten</kldb>
     </antwort>
     <antwort position="2" anforderungsniveau="3">
       <text>eine vertiefende berufliche Weiterbildung mit Mindestdauer von 18 Monaten</text>
-      <kldb schluessel="43113">Berufe in der Wirtschaftsinformatik - komplexe Spezialistentätigkeiten</kldb>
     </antwort>
     <antwort position="3" anforderungsniveau="3">
       <text>ein abgeschlossenes Bachelorstudium in Informatik, Wirtschafsinformatik oder ein vergleichbares Studium</text>
-      <kldb schluessel="43113">Berufe in der Wirtschaftsinformatik - komplexe Spezialistentätigkeiten</kldb>
     </antwort>
     <antwort position="4" anforderungsniveau="4">
       <text>ein abgeschlossenes Masterstudium in Informatik, Wirtschafsinformatik oder ein vergleichbares Studium</text>
-      <kldb schluessel="43114">Berufe in der Wirtschaftsinformatik - hoch komplexe Tätigkeiten</kldb>
     </antwort>
+    <aggregation>
+      <bedingung frage_1_antwort_pos="1" frage_2_antwort_pos="1">
+        <isco schluessel="2511">Systems analysts</isco>
+        <kldb schluessel="43112">Berufe in der Wirtschaftsinformatik - fachlich ausgerichtete Tätigkeiten</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="2" frage_2_antwort_pos="1">
+        <isco schluessel="2512">Software developers</isco>
+        <kldb schluessel="43112">Berufe in der Wirtschaftsinformatik - fachlich ausgerichtete Tätigkeiten</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="3" frage_2_antwort_pos="1">
+        <isco schluessel="2513">Web and Multimedia Developers</isco>
+        <kldb schluessel="43112">Berufe in der Wirtschaftsinformatik - fachlich ausgerichtete Tätigkeiten</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="4" frage_2_antwort_pos="1">
+        <isco schluessel="2514">Application Programmers</isco>
+        <kldb schluessel="43112">Berufe in der Wirtschaftsinformatik - fachlich ausgerichtete Tätigkeiten</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="5" frage_2_antwort_pos="1">
+        <isco schluessel="2521">Database Designers and Administrators</isco>
+        <kldb schluessel="43112">Berufe in der Wirtschaftsinformatik - fachlich ausgerichtete Tätigkeiten</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="6" frage_2_antwort_pos="1">
+        <isco schluessel="2522">Systems Administrators</isco>
+        <kldb schluessel="43112">Berufe in der Wirtschaftsinformatik - fachlich ausgerichtete Tätigkeiten</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="7" frage_2_antwort_pos="1">
+        <isco schluessel="2523">Computer Network Professionals</isco>
+        <kldb schluessel="43112">Berufe in der Wirtschaftsinformatik - fachlich ausgerichtete Tätigkeiten</kldb>
+      </bedingung>
+
+      <bedingung frage_1_antwort_pos="1" frage_2_antwort_pos="2">
+        <isco schluessel="2511">Systems analysts</isco>
+        <kldb schluessel="43113">Berufe in der Wirtschaftsinformatik - komplexe Spezialistentätigkeiten</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="2" frage_2_antwort_pos="2">
+        <isco schluessel="2512">Software developers</isco>
+        <kldb schluessel="43113">Berufe in der Wirtschaftsinformatik - komplexe Spezialistentätigkeiten</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="3" frage_2_antwort_pos="2">
+        <isco schluessel="2513">Web and Multimedia Developers</isco>
+        <kldb schluessel="43113">Berufe in der Wirtschaftsinformatik - komplexe Spezialistentätigkeiten</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="4" frage_2_antwort_pos="2">
+        <isco schluessel="2514">Application Programmers</isco>
+        <kldb schluessel="43113">Berufe in der Wirtschaftsinformatik - komplexe Spezialistentätigkeiten</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="5" frage_2_antwort_pos="2">
+        <isco schluessel="2521">Database Designers and Administrators</isco>
+        <kldb schluessel="43113">Berufe in der Wirtschaftsinformatik - komplexe Spezialistentätigkeiten</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="6" frage_2_antwort_pos="2">
+        <isco schluessel="2522">Systems Administrators</isco>
+        <kldb schluessel="43113">Berufe in der Wirtschaftsinformatik - komplexe Spezialistentätigkeiten</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="7" frage_2_antwort_pos="2">
+        <isco schluessel="2523">Computer Network Professionals</isco>
+        <kldb schluessel="43113">Berufe in der Wirtschaftsinformatik - komplexe Spezialistentätigkeiten</kldb>
+      </bedingung>
+
+      <bedingung frage_1_antwort_pos="1" frage_2_antwort_pos="3">
+        <isco schluessel="2511">Systems analysts</isco>
+        <kldb schluessel="43113">Berufe in der Wirtschaftsinformatik - komplexe Spezialistentätigkeiten</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="2" frage_2_antwort_pos="3">
+        <isco schluessel="2512">Software developers</isco>
+        <kldb schluessel="43113">Berufe in der Wirtschaftsinformatik - komplexe Spezialistentätigkeiten</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="3" frage_2_antwort_pos="3">
+        <isco schluessel="2513">Web and Multimedia Developers</isco>
+        <kldb schluessel="43113">Berufe in der Wirtschaftsinformatik - komplexe Spezialistentätigkeiten</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="4" frage_2_antwort_pos="3">
+        <isco schluessel="2514">Application Programmers</isco>
+        <kldb schluessel="43113">Berufe in der Wirtschaftsinformatik - komplexe Spezialistentätigkeiten</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="5" frage_2_antwort_pos="3">
+        <isco schluessel="2521">Database Designers and Administrators</isco>
+        <kldb schluessel="43113">Berufe in der Wirtschaftsinformatik - komplexe Spezialistentätigkeiten</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="6" frage_2_antwort_pos="3">
+        <isco schluessel="2522">Systems Administrators</isco>
+        <kldb schluessel="43113">Berufe in der Wirtschaftsinformatik - komplexe Spezialistentätigkeiten</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="7" frage_2_antwort_pos="3">
+        <isco schluessel="2523">Computer Network Professionals</isco>
+        <kldb schluessel="43113">Berufe in der Wirtschaftsinformatik - komplexe Spezialistentätigkeiten</kldb>
+      </bedingung>
+
+      <bedingung frage_1_antwort_pos="1" frage_2_antwort_pos="4">
+        <isco schluessel="2511">Systems analysts</isco>
+        <kldb schluessel="43114">Berufe in der Wirtschaftsinformatik - hoch komplexe Tätigkeiten</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="2" frage_2_antwort_pos="4">
+        <isco schluessel="2512">Software developers</isco>
+        <kldb schluessel="43114">Berufe in der Wirtschaftsinformatik - hoch komplexe Tätigkeiten</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="3" frage_2_antwort_pos="4">
+        <isco schluessel="2513">Web and Multimedia Developers</isco>
+        <kldb schluessel="43114">Berufe in der Wirtschaftsinformatik - hoch komplexe Tätigkeiten</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="4" frage_2_antwort_pos="4">
+        <isco schluessel="2514">Application Programmers</isco>
+        <kldb schluessel="43114">Berufe in der Wirtschaftsinformatik - hoch komplexe Tätigkeiten</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="5" frage_2_antwort_pos="4">
+        <isco schluessel="2521">Database Designers and Administrators</isco>
+        <kldb schluessel="43114">Berufe in der Wirtschaftsinformatik - hoch komplexe Tätigkeiten</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="6" frage_2_antwort_pos="4">
+        <isco schluessel="2522">Systems Administrators</isco>
+        <kldb schluessel="43114">Berufe in der Wirtschaftsinformatik - hoch komplexe Tätigkeiten</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="7" frage_2_antwort_pos="4">
+        <isco schluessel="2523">Computer Network Professionals</isco>
+        <kldb schluessel="43114">Berufe in der Wirtschaftsinformatik - hoch komplexe Tätigkeiten</kldb>
+      </bedingung>
+    </aggregation>
   </untergliederung>
   <abgrenzung typ="mittel" refid="4038">Informatiker/in</abgrenzung>
   <abgrenzung typ="mittel" refid="4037">Technische/r Informatiker/in</abgrenzung>

--- a/auxco_src_files/4_Naturwissenschaft_Geografie_und_Informatik/4037_Technische-r_Informatiker-in.xml
+++ b/auxco_src_files/4_Naturwissenschaft_Geografie_und_Informatik/4037_Technische-r_Informatiker-in.xml
@@ -24,35 +24,27 @@
     </fragetext>
     <antwort position="1">
       <text>Konzeption von speziellen IT-Systemen für verschiedene Aufgaben und Anwenderbedürfnisse</text>
-      <isco schluessel="2511">Systems analysts</isco>
     </antwort>
     <antwort position="2">
       <text>Entwurf und Entwicklung von Computersoftware</text>
-      <isco schluessel="2512">Software developers</isco>
     </antwort>
     <antwort position="3">
       <text>Entwicklung von Steuerprogrammen für elektrotechnische Geräte und Maschinen</text>
-      <isco schluessel="2152">Electronics engineers</isco>
     </antwort>
     <antwort position="4">
       <text>Entwicklung und Wartung von Code</text>
-      <isco schluessel="2514">Application Programmers</isco>
     </antwort>
     <antwort position="5">
       <text>Verwaltung von Netzwerkdaten und Computernetzwerken</text>
-      <isco schluessel="3513">Computer network and systems technicians</isco>
     </antwort>
     <antwort position="6">
       <text>Überwachung von Hardware, Software und Computerzubehör; um optimale Leistung zu garantieren</text>
-      <isco schluessel="3511">Information and communications technology operations technicians</isco>
     </antwort>
     <antwort position="7">
       <text>Erforschung und Weiterentwicklung von Netzwerkarchitekturen zur Leistungsoptimierung</text>
-      <isco schluessel="2523">Computer Network Professionals</isco>
     </antwort>
     <antwort position="8">
       <text>Oder etwas anderes?</text>
-      <isco schluessel="????">Freitextantwort</isco>
     </antwort>
     <fragetext typ="anforderungsniveau">
       <folgefrageAktuellerBeruf>Welche Art von Ausbildung ist für Ihre Tätigkeit in der Regel erforderlich?</folgefrageAktuellerBeruf>
@@ -60,20 +52,134 @@
     </fragetext>
     <antwort position="1" anforderungsniveau="2">
       <text>eine abgeschlossene Berufsausbildung</text>
-      <kldb schluessel="43122">Technische Informatik - Fachkraft</kldb>
     </antwort>
     <antwort position="2" anforderungsniveau="3">
       <text>eine vertiefende berufliche Weiterbildung mit Mindestdauer von 18 Monaten</text>
-      <kldb schluessel="43123">Technische Informatik - Spezialist</kldb>
     </antwort>
     <antwort position="3" anforderungsniveau="3">
       <text>ein abgeschlossenes Bachelorstudium in Informatik, Wirtschafsinformatik oder ein vergleichbares Studium</text>
-      <kldb schluessel="43123">Technische Informatik - Spezialist</kldb>
     </antwort>
     <antwort position="4" anforderungsniveau="4">
       <text>ein abgeschlossenes Masterstudium in Informatik, Wirtschafsinformatik oder ein vergleichbares Studium</text>
-      <kldb schluessel="43124">Technische Informatik - Experte</kldb>
     </antwort>
+
+    <aggregation>
+      <bedingung frage_1_antwort_pos="1" frage_2_antwort_pos="1">
+        <isco schluessel="2511">Systems analysts</isco>
+        <kldb schluessel="43122">Technische Informatik - Fachkraft</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="2" frage_2_antwort_pos="1">
+        <isco schluessel="2512">Software developers</isco>
+        <kldb schluessel="43122">Technische Informatik - Fachkraft</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="3" frage_2_antwort_pos="1">
+        <isco schluessel="2152">Electronics engineers</isco>
+        <kldb schluessel="43122">Technische Informatik - Fachkraft</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="4" frage_2_antwort_pos="1">
+        <isco schluessel="2514">Application Programmers</isco>
+        <kldb schluessel="43122">Technische Informatik - Fachkraft</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="5" frage_2_antwort_pos="1">
+        <isco schluessel="3513">Computer network and systems technicians</isco>
+        <kldb schluessel="43122">Technische Informatik - Fachkraft</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="6" frage_2_antwort_pos="1">
+        <isco schluessel="3511">Information and communications technology operations technicians</isco>
+        <kldb schluessel="43122">Technische Informatik - Fachkraft</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="7" frage_2_antwort_pos="1">
+        <isco schluessel="2523">Computer Network Professionals</isco>
+        <kldb schluessel="43122">Technische Informatik - Fachkraft</kldb>
+      </bedingung>
+
+      <bedingung frage_1_antwort_pos="1" frage_2_antwort_pos="2">
+        <isco schluessel="2511">Systems analysts</isco>
+        <kldb schluessel="43123">Technische Informatik - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="2" frage_2_antwort_pos="2">
+        <isco schluessel="2512">Software developers</isco>
+        <kldb schluessel="43123">Technische Informatik - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="3" frage_2_antwort_pos="2">
+        <isco schluessel="2152">Electronics engineers</isco>
+        <kldb schluessel="43123">Technische Informatik - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="4" frage_2_antwort_pos="2">
+        <isco schluessel="2514">Application Programmers</isco>
+        <kldb schluessel="43123">Technische Informatik - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="5" frage_2_antwort_pos="2">
+        <isco schluessel="3513">Computer network and systems technicians</isco>
+        <kldb schluessel="43123">Technische Informatik - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="6" frage_2_antwort_pos="2">
+        <isco schluessel="3511">Information and communications technology operations technicians</isco>
+        <kldb schluessel="43123">Technische Informatik - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="7" frage_2_antwort_pos="2">
+        <isco schluessel="2523">Computer Network Professionals</isco>
+        <kldb schluessel="43123">Technische Informatik - Spezialist</kldb>
+      </bedingung>
+
+      <bedingung frage_1_antwort_pos="1" frage_2_antwort_pos="3">
+        <isco schluessel="2511">Systems analysts</isco>
+        <kldb schluessel="43123">Technische Informatik - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="2" frage_2_antwort_pos="3">
+        <isco schluessel="2512">Software developers</isco>
+        <kldb schluessel="43123">Technische Informatik - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="3" frage_2_antwort_pos="3">
+        <isco schluessel="2152">Electronics engineers</isco>
+        <kldb schluessel="43123">Technische Informatik - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="4" frage_2_antwort_pos="3">
+        <isco schluessel="2514">Application Programmers</isco>
+        <kldb schluessel="43123">Technische Informatik - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="5" frage_2_antwort_pos="3">
+        <isco schluessel="3513">Computer network and systems technicians</isco>
+        <kldb schluessel="43123">Technische Informatik - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="6" frage_2_antwort_pos="3">
+        <isco schluessel="3511">Information and communications technology operations technicians</isco>
+        <kldb schluessel="43123">Technische Informatik - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="7" frage_2_antwort_pos="3">
+        <isco schluessel="2523">Computer Network Professionals</isco>
+        <kldb schluessel="43123">Technische Informatik - Spezialist</kldb>
+      </bedingung>
+
+      <bedingung frage_1_antwort_pos="1" frage_2_antwort_pos="4">
+        <isco schluessel="2511">Systems analysts</isco>
+        <kldb schluessel="43124">Technische Informatik - Experte</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="2" frage_2_antwort_pos="4">
+        <isco schluessel="2512">Software developers</isco>
+        <kldb schluessel="43124">Technische Informatik - Experte</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="3" frage_2_antwort_pos="4">
+        <isco schluessel="2152">Electronics engineers</isco>
+        <kldb schluessel="43124">Technische Informatik - Experte</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="4" frage_2_antwort_pos="4">
+        <isco schluessel="2514">Application Programmers</isco>
+        <kldb schluessel="43124">Technische Informatik - Experte</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="5" frage_2_antwort_pos="4">
+        <isco schluessel="3513">Computer network and systems technicians</isco>
+        <kldb schluessel="43124">Technische Informatik - Experte</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="6" frage_2_antwort_pos="4">
+        <isco schluessel="3511">Information and communications technology operations technicians</isco>
+        <kldb schluessel="43124">Technische Informatik - Experte</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="7" frage_2_antwort_pos="4">
+        <isco schluessel="2523">Computer Network Professionals</isco>
+        <kldb schluessel="43124">Technische Informatik - Experte</kldb>
+      </bedingung>
+    </aggregation>
   </untergliederung>
   <abgrenzung typ="hoch" refid="4038">Informatiker/in</abgrenzung>
   <abgrenzung typ="hoch" refid="4250">Leiter/in - Informatik und Informationsmanagement</abgrenzung>

--- a/auxco_src_files/4_Naturwissenschaft_Geografie_und_Informatik/4037_Technische-r_Informatiker-in.xml
+++ b/auxco_src_files/4_Naturwissenschaft_Geografie_und_Informatik/4037_Technische-r_Informatiker-in.xml
@@ -43,9 +43,6 @@
     <antwort position="7">
       <text>Erforschung und Weiterentwicklung von Netzwerkarchitekturen zur Leistungsoptimierung</text>
     </antwort>
-    <antwort position="8">
-      <text>Oder etwas anderes?</text>
-    </antwort>
     <fragetext typ="anforderungsniveau">
       <folgefrageAktuellerBeruf>Welche Art von Ausbildung ist für Ihre Tätigkeit in der Regel erforderlich?</folgefrageAktuellerBeruf>
       <folgefrageVergangenerBeruf>Welche Art von Ausbildung war für diese Tätigkeit in der Regel erforderlich?</folgefrageVergangenerBeruf>

--- a/auxco_src_files/4_Naturwissenschaft_Geografie_und_Informatik/4038_Informatiker-in.xml
+++ b/auxco_src_files/4_Naturwissenschaft_Geografie_und_Informatik/4038_Informatiker-in.xml
@@ -20,43 +20,30 @@
     </fragetext>
     <antwort position="1">
       <text>Konzeption von speziellen IT-Systemen für verschiedene Aufgaben und Anwenderbedürfnisse</text>
-      <isco schluessel="2511">Systems analysts</isco>
     </antwort>
     <antwort position="2">
       <text>Technischer Support für Problemdiagnosen und Fehlerbehebungen</text>
-      <isco schluessel="3512">Information and communications technology user support technicians</isco>
     </antwort>
     <antwort position="3">
       <text>Errichtung und Verwaltung von Computernetzwerken</text>
-      <isco schluessel="3513">Computer network and systems technicians</isco>
     </antwort>
     <antwort position="4">
       <text>Wartung und Administration von Webseiten</text>
-      <isco schluessel="3514">Web technicians</isco>
     </antwort>
     <antwort position="5">
       <text>Entwurf und Entwicklung von Computersoftware</text>
-      <isco schluessel="2512">Software developers</isco>
     </antwort>
     <antwort position="6">
       <text>Schreiben und Wartung von Programmcode</text>
-      <isco schluessel="2514">Application Programmers</isco>
     </antwort>
     <antwort position="7">
       <text>Entwicklung, Kontrolle und Wartung von Datenbanken</text>
-      <isco schluessel="2521">Database Designers and Administrators</isco>
     </antwort>
     <antwort position="8">
       <text>Wartung und Verwaltung von informationstechnischen Systemen</text>
-      <isco schluessel="2522">Systems Administrators</isco>
     </antwort>
     <antwort position="9">
       <text>Erforschung und Weiterentwicklung von Netzwerkarchitekturen zur Leistungsoptimierung</text>
-      <isco schluessel="2523">Computer Network Professionals</isco>
-    </antwort>
-    <antwort position="10">
-      <text>Oder etwas anderes?</text>
-      <isco schluessel="????">Freitextantwort</isco>
     </antwort>
     <fragetext typ="anforderungsniveau">
       <folgefrageAktuellerBeruf>Welche Art von Ausbildung ist für Ihre Tätigkeit in der Regel erforderlich?</folgefrageAktuellerBeruf>
@@ -64,20 +51,166 @@
     </fragetext>
     <antwort position="1" anforderungsniveau="2">
       <text>eine abgeschlossene Berufsausbildung</text>
-      <kldb schluessel="43102">Informatik (o.S.) - Fachkraft</kldb>
     </antwort>
     <antwort position="2" anforderungsniveau="3">
       <text>eine vertiefende berufliche Weiterbildung mit Mindestdauer von 18 Monaten</text>
-      <kldb schluessel="43103">Informatik (o.S.) - Spezialist</kldb>
     </antwort>
     <antwort position="3" anforderungsniveau="3">
       <text>ein abgeschlossenes Bachelorstudium in Informatik, Medieninformatik oder ein vergleichbares Studium</text>
-      <kldb schluessel="43103">Informatik (o.S.) - Spezialist</kldb>
     </antwort>
     <antwort position="4" anforderungsniveau="4">
       <text>ein abgeschlossenes Masterstudium in Informatik, Medieninformatik oder ein vergleichbares Studium</text>
-      <kldb schluessel="43104">Informatik (o.S.) - Experte</kldb>
     </antwort>
+
+    <aggregation>
+      <bedingung frage_1_antwort_pos="1" frage_2_antwort_pos="1">
+        <isco schluessel="2511">Systems analysts</isco>
+        <kldb schluessel="43102">Informatik (o.S.) - Fachkraft</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="2" frage_2_antwort_pos="1">
+        <isco schluessel="3512">Information and communications technology user support technicians</isco>
+        <kldb schluessel="43102">Informatik (o.S.) - Fachkraft</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="3" frage_2_antwort_pos="1">
+        <isco schluessel="3513">Computer network and systems technicians</isco>
+        <kldb schluessel="43102">Informatik (o.S.) - Fachkraft</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="4" frage_2_antwort_pos="1">
+        <isco schluessel="3514">Web technicians</isco>
+        <kldb schluessel="43102">Informatik (o.S.) - Fachkraft</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="5" frage_2_antwort_pos="1">
+        <isco schluessel="2512">Software developers</isco>
+        <kldb schluessel="43102">Informatik (o.S.) - Fachkraft</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="6" frage_2_antwort_pos="1">
+        <isco schluessel="2514">Application Programmers</isco>
+        <kldb schluessel="43102">Informatik (o.S.) - Fachkraft</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="7" frage_2_antwort_pos="1">
+        <isco schluessel="2521">Database Designers and Administrators</isco>
+        <kldb schluessel="43102">Informatik (o.S.) - Fachkraft</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="8" frage_2_antwort_pos="1">
+        <isco schluessel="2522">Systems Administrators</isco>
+        <kldb schluessel="43102">Informatik (o.S.) - Fachkraft</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="9" frage_2_antwort_pos="1">
+        <isco schluessel="2523">Computer Network Professionals</isco>
+        <kldb schluessel="43102">Informatik (o.S.) - Fachkraft</kldb>
+      </bedingung>
+
+      <bedingung frage_1_antwort_pos="1" frage_2_antwort_pos="2">
+        <isco schluessel="2511">Systems analysts</isco>
+        <kldb schluessel="43103">Informatik (o.S.) - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="2" frage_2_antwort_pos="2">
+        <isco schluessel="3512">Information and communications technology user support technicians</isco>
+        <kldb schluessel="43103">Informatik (o.S.) - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="3" frage_2_antwort_pos="2">
+        <isco schluessel="3513">Computer network and systems technicians</isco>
+        <kldb schluessel="43103">Informatik (o.S.) - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="4" frage_2_antwort_pos="2">
+        <isco schluessel="3514">Web technicians</isco>
+        <kldb schluessel="43103">Informatik (o.S.) - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="5" frage_2_antwort_pos="2">
+        <isco schluessel="2512">Software developers</isco>
+        <kldb schluessel="43103">Informatik (o.S.) - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="6" frage_2_antwort_pos="2">
+        <isco schluessel="2514">Application Programmers</isco>
+        <kldb schluessel="43103">Informatik (o.S.) - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="7" frage_2_antwort_pos="2">
+        <isco schluessel="2521">Database Designers and Administrators</isco>
+        <kldb schluessel="43103">Informatik (o.S.) - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="8" frage_2_antwort_pos="2">
+        <isco schluessel="2522">Systems Administrators</isco>
+        <kldb schluessel="43103">Informatik (o.S.) - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="9" frage_2_antwort_pos="2">
+        <isco schluessel="2523">Computer Network Professionals</isco>
+        <kldb schluessel="43103">Informatik (o.S.) - Spezialist</kldb>
+      </bedingung>
+
+      <bedingung frage_1_antwort_pos="1" frage_2_antwort_pos="3">
+        <isco schluessel="2511">Systems analysts</isco>
+        <kldb schluessel="43103">Informatik (o.S.) - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="2" frage_2_antwort_pos="3">
+        <isco schluessel="3512">Information and communications technology user support technicians</isco>
+        <kldb schluessel="43103">Informatik (o.S.) - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="3" frage_2_antwort_pos="3">
+        <isco schluessel="3513">Computer network and systems technicians</isco>
+        <kldb schluessel="43103">Informatik (o.S.) - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="4" frage_2_antwort_pos="3">
+        <isco schluessel="3514">Web technicians</isco>
+        <kldb schluessel="43103">Informatik (o.S.) - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="5" frage_2_antwort_pos="3">
+        <isco schluessel="2512">Software developers</isco>
+        <kldb schluessel="43103">Informatik (o.S.) - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="6" frage_2_antwort_pos="3">
+        <isco schluessel="2514">Application Programmers</isco>
+        <kldb schluessel="43103">Informatik (o.S.) - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="7" frage_2_antwort_pos="3">
+        <isco schluessel="2521">Database Designers and Administrators</isco>
+        <kldb schluessel="43103">Informatik (o.S.) - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="8" frage_2_antwort_pos="3">
+        <isco schluessel="2522">Systems Administrators</isco>
+        <kldb schluessel="43103">Informatik (o.S.) - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="9" frage_2_antwort_pos="3">
+        <isco schluessel="2523">Computer Network Professionals</isco>
+        <kldb schluessel="43103">Informatik (o.S.) - Spezialist</kldb>
+      </bedingung>
+
+      <bedingung frage_1_antwort_pos="1" frage_2_antwort_pos="4">
+        <isco schluessel="2511">Systems analysts</isco>
+        <kldb schluessel="43104">Informatik (o.S.) - Experte</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="2" frage_2_antwort_pos="4">
+        <isco schluessel="3512">Information and communications technology user support technicians</isco>
+        <kldb schluessel="43104">Informatik (o.S.) - Experte</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="3" frage_2_antwort_pos="4">
+        <isco schluessel="3513">Computer network and systems technicians</isco>
+        <kldb schluessel="43104">Informatik (o.S.) - Experte</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="4" frage_2_antwort_pos="4">
+        <isco schluessel="3514">Web technicians</isco>
+        <kldb schluessel="43104">Informatik (o.S.) - Experte</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="5" frage_2_antwort_pos="4">
+        <isco schluessel="2512">Software developers</isco>
+        <kldb schluessel="43104">Informatik (o.S.) - Experte</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="6" frage_2_antwort_pos="4">
+        <isco schluessel="2514">Application Programmers</isco>
+        <kldb schluessel="43104">Informatik (o.S.) - Experte</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="7" frage_2_antwort_pos="4">
+        <isco schluessel="2521">Database Designers and Administrators</isco>
+        <kldb schluessel="43104">Informatik (o.S.) - Experte</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="8" frage_2_antwort_pos="4">
+        <isco schluessel="2522">Systems Administrators</isco>
+        <kldb schluessel="43104">Informatik (o.S.) - Experte</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="9" frage_2_antwort_pos="4">
+        <isco schluessel="2523">Computer Network Professionals</isco>
+        <kldb schluessel="43104">Informatik (o.S.) - Experte</kldb>
+      </bedingung>
+    </aggregation>
   </untergliederung>
   <abgrenzung typ="mittel" refid="1770">ERP-Anwendungsentwickler</abgrenzung>
   <abgrenzung typ="mittel" refid="4061">Softwareentwickler/in</abgrenzung>

--- a/auxco_src_files/4_Naturwissenschaft_Geografie_und_Informatik/4043_Medieninformatiker-in.xml
+++ b/auxco_src_files/4_Naturwissenschaft_Geografie_und_Informatik/4043_Medieninformatiker-in.xml
@@ -23,27 +23,18 @@
     </fragetext>
     <antwort position="1">
       <text>Entwurf und Entwicklung von Computersoftware</text>
-      <isco schluessel="2512">Software developers</isco>
     </antwort>
     <antwort position="2">
       <text>Entwicklung und Entwurf von Webseiten, Grafiken, Videos und Animationen</text>
-      <isco schluessel="2513">Web and Multimedia Developers</isco>
     </antwort>
     <antwort position="3">
       <text>Entwicklung und Wartung von Code</text>
-      <isco schluessel="2514">Application Programmers</isco>
     </antwort>
     <antwort position="4">
       <text>Entwicklung, Kontrolle und Wartung von Datenbanken</text>
-      <isco schluessel="2521">Database Designers and Administrators</isco>
     </antwort>
     <antwort position="5">
       <text>Wartung und Administration von Webseiten</text>
-      <isco schluessel="3514">Web technicians</isco>
-    </antwort>
-    <antwort position="6">
-      <text>Oder etwas anderes?</text>
-      <isco schluessel="????">Freitextantwort</isco>
     </antwort>
     <fragetext typ="anforderungsniveau">
       <folgefrageAktuellerBeruf>Welche Art von Ausbildung ist für Ihre Tätigkeit in der Regel erforderlich?</folgefrageAktuellerBeruf>
@@ -51,20 +42,102 @@
     </fragetext>
     <antwort position="1" anforderungsniveau="2">
       <text>eine abgeschlossene Berufsausbildung</text>
-      <kldb schluessel="43152">Medieninformatik - Fachkraft</kldb>
     </antwort>
     <antwort position="2" anforderungsniveau="3">
       <text>eine vertiefende berufliche Weiterbildung mit Mindestdauer von 18 Monaten</text>
-      <kldb schluessel="43153">Medieninformatik - Spezialist</kldb>
     </antwort>
     <antwort position="3" anforderungsniveau="3">
       <text>ein abgeschlossenes Bachelorstudium in Informatik, Medieninformatik oder ein vergleichbares Studium</text>
-      <kldb schluessel="43153">Medieninformatik - Spezialist</kldb>
     </antwort>
     <antwort position="4" anforderungsniveau="4">
       <text>ein abgeschlossenes Masterstudium in Informatik, Medieninformatik oder ein vergleichbares Studium</text>
-      <kldb schluessel="43154">Medieninformatik - Experte</kldb>
     </antwort>
+
+    <aggregation>
+      <bedingung frage_1_antwort_pos="1" frage_2_antwort_pos="1">
+        <isco schluessel="2512">Software developers</isco>
+        <kldb schluessel="43152">Medieninformatik - Fachkraft</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="2" frage_2_antwort_pos="1">
+        <isco schluessel="2513">Web and Multimedia Developers</isco>
+        <kldb schluessel="43152">Medieninformatik - Fachkraft</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="3" frage_2_antwort_pos="1">
+        <isco schluessel="2514">Application Programmers</isco>
+        <kldb schluessel="43152">Medieninformatik - Fachkraft</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="4" frage_2_antwort_pos="1">
+        <isco schluessel="2521">Database Designers and Administrators</isco>
+        <kldb schluessel="43152">Medieninformatik - Fachkraft</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="5" frage_2_antwort_pos="1">
+        <isco schluessel="3514">Web technicians</isco>
+        <kldb schluessel="43152">Medieninformatik - Fachkraft</kldb>
+      </bedingung>
+
+      <bedingung frage_1_antwort_pos="1" frage_2_antwort_pos="2">
+        <isco schluessel="2512">Software developers</isco>
+        <kldb schluessel="43153">Medieninformatik - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="2" frage_2_antwort_pos="2">
+        <isco schluessel="2513">Web and Multimedia Developers</isco>
+        <kldb schluessel="43153">Medieninformatik - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="3" frage_2_antwort_pos="2">
+        <isco schluessel="2514">Application Programmers</isco>
+        <kldb schluessel="43153">Medieninformatik - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="4" frage_2_antwort_pos="2">
+        <isco schluessel="2521">Database Designers and Administrators</isco>
+        <kldb schluessel="43153">Medieninformatik - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="5" frage_2_antwort_pos="2">
+        <isco schluessel="3514">Web technicians</isco>
+        <kldb schluessel="43153">Medieninformatik - Spezialist</kldb>
+      </bedingung>
+
+      <bedingung frage_1_antwort_pos="1" frage_2_antwort_pos="3">
+        <isco schluessel="2512">Software developers</isco>
+        <kldb schluessel="43153">Medieninformatik - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="2" frage_2_antwort_pos="3">
+        <isco schluessel="2513">Web and Multimedia Developers</isco>
+        <kldb schluessel="43153">Medieninformatik - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="3" frage_2_antwort_pos="3">
+        <isco schluessel="2514">Application Programmers</isco>
+        <kldb schluessel="43153">Medieninformatik - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="4" frage_2_antwort_pos="3">
+        <isco schluessel="2521">Database Designers and Administrators</isco>
+        <kldb schluessel="43153">Medieninformatik - Spezialist</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="5" frage_2_antwort_pos="3">
+        <isco schluessel="3514">Web technicians</isco>
+        <kldb schluessel="43153">Medieninformatik - Spezialist</kldb>
+      </bedingung>
+
+      <bedingung frage_1_antwort_pos="1" frage_2_antwort_pos="4">
+        <isco schluessel="2512">Software developers</isco>
+        <kldb schluessel="43154">Medieninformatik - Experte</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="2" frage_2_antwort_pos="4">
+        <isco schluessel="2513">Web and Multimedia Developers</isco>
+        <kldb schluessel="43154">Medieninformatik - Experte</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="3" frage_2_antwort_pos="4">
+        <isco schluessel="2514">Application Programmers</isco>
+        <kldb schluessel="43154">Medieninformatik - Experte</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="4" frage_2_antwort_pos="4">
+        <isco schluessel="2521">Database Designers and Administrators</isco>
+        <kldb schluessel="43154">Medieninformatik - Experte</kldb>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="5" frage_2_antwort_pos="4">
+        <isco schluessel="3514">Web technicians</isco>
+        <kldb schluessel="43154">Medieninformatik - Experte</kldb>
+      </bedingung>
+    </aggregation>
   </untergliederung>
   <abgrenzung typ="mittel" refid="4038">Informatiker/in</abgrenzung>
   <abgrenzung typ="mittel" refid="1770">ERP-Anwendungsentwickler</abgrenzung>

--- a/auxco_src_files/5_Verkehr_Logistik_Schutz_und_Sicherheit/9900_Luftverkehrskaufmann--frau.xml
+++ b/auxco_src_files/5_Verkehr_Logistik_Schutz_und_Sicherheit/9900_Luftverkehrskaufmann--frau.xml
@@ -19,11 +19,9 @@
     </fragetext>
     <antwort position="1" anforderungsniveau="3">
       <text>Ja</text>
-      <kldb schluessel="51643">Luftverkehrskaufleute - komplexe Spezialistentätigkeiten</kldb>
     </antwort>
     <antwort position="2" anforderungsniveau="2">
       <text>Nein</text>
-      <kldb schluessel="51642">Luftverkehrskaufleute - fachlich ausgerichtete Tätigkeiten</kldb>
     </antwort>
     <fragetext typ="spezialisierung">
       <folgefrageAktuellerBeruf>Welche Aufgaben führen Sie dabei in der Regel aus?</folgefrageAktuellerBeruf>
@@ -31,16 +29,42 @@
     </fragetext>
     <antwort position="1">
       <text>für Fluggäste Beratungs- und Serviceleistungen erbringen</text>
-      <isco schluessel="4221">Travel consultants and clerks</isco>
     </antwort>
     <antwort position="2">
       <text>mit anderen Unternehmen Geschäftsbeziehungen unterhalten</text>
-      <isco schluessel="3324">Trade brokers</isco>
     </antwort>
     <antwort position="3">
       <text>Transportleistungen koordinieren</text>
-      <isco schluessel="4323">Transport clerks</isco>
     </antwort>
+
+    <aggregation>
+      <bedingung frage_1_antwort_pos="1" frage_2_antwort_pos="1">
+        <kldb schluessel="51643">Luftverkehrskaufleute - komplexe Spezialistentätigkeiten</kldb>
+        <isco schluessel="4221">Travel consultants and clerks</isco>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="2" frage_2_antwort_pos="1">
+        <kldb schluessel="51642">Luftverkehrskaufleute - fachlich ausgerichtete Tätigkeiten</kldb>
+        <isco schluessel="4221">Travel consultants and clerks</isco>
+      </bedingung>
+
+      <bedingung frage_1_antwort_pos="1" frage_2_antwort_pos="2">
+        <kldb schluessel="51643">Luftverkehrskaufleute - komplexe Spezialistentätigkeiten</kldb>
+        <isco schluessel="3324">Trade brokers</isco>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="2" frage_2_antwort_pos="2">
+        <kldb schluessel="51642">Luftverkehrskaufleute - fachlich ausgerichtete Tätigkeiten</kldb>
+        <isco schluessel="3324">Trade brokers</isco>
+      </bedingung>
+
+      <bedingung frage_1_antwort_pos="1" frage_2_antwort_pos="3">
+        <kldb schluessel="51643">Luftverkehrskaufleute - komplexe Spezialistentätigkeiten</kldb>
+        <isco schluessel="4323">Transport clerks</isco>
+      </bedingung>
+      <bedingung frage_1_antwort_pos="2" frage_2_antwort_pos="3">
+        <kldb schluessel="51642">Luftverkehrskaufleute - fachlich ausgerichtete Tätigkeiten</kldb>
+        <isco schluessel="4323">Transport clerks</isco>
+      </bedingung>
+    </aggregation>
   </untergliederung>
   <abgrenzung typ="hoch" refid="1000">Schalterangestellte/r - Flughafen</abgrenzung>
   <abgrenzung typ="mittel" refid="1001">Steward/Stewardess (Flugzeug)</abgrenzung>


### PR DESCRIPTION
This PR replaces all uses of followup question answers that have only an isco OR kldb code (because each question is specific to one of the two encoding systems) with aggregation blocks instead to handle the same logic, but using only one type of decision system.